### PR TITLE
 Remove @Override

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNPdfScannerPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNPdfScannerPackage.java
@@ -16,7 +16,6 @@ public class RNPdfScannerPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNPdfScannerModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
this will make compatible with react native 0.47+ and prevents build errors when using 
"react-native link react-native-document-scanner" as you describe on readme.